### PR TITLE
Use a single beep command instead of multiple for fluidity

### DIFF
--- a/Song Pack/phasor
+++ b/Song Pack/phasor
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-n=3000; while [ $n -gt 400 ]; do beep -f $n -l 5; n=$((n*97/100)); done
+eval beep $(n=3000; while [ $n -gt 400 ]; do echo " -n -f $n -l 5"; n=$((n*97/100)); done)

--- a/Song Pack/phasor
+++ b/Song Pack/phasor
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-eval beep $(n=3000; while [ $n -gt 400 ]; do echo " -n -f $n -l 5"; n=$((n*97/100)); done)
+beep $(n=3000; while [ $n -gt 400 ]; do echo " -n -f $n -l 5"; n=$((n*97/100)); done)


### PR DESCRIPTION
Due to the delay caused by executed a lot of beep commands, the original script does not produce always fluid sound. This diff invokes single beep command with the arguments being generated by loop instead of running the command multiple times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the `phasor` script to dynamically construct and execute the `beep` command using an `eval` statement for more efficient command generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->